### PR TITLE
Prepare scorecard workflow for updated block list

### DIFF
--- a/.github/workflows/_scorecards.yml
+++ b/.github/workflows/_scorecards.yml
@@ -9,6 +9,7 @@ on:
     - cron: '43 4 * * 4'
   push:
     branches: ["develop"]
+  workflow_dispatch:
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -30,7 +31,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09  # tag=v2.5.1
         with:
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             api.github.com:443
             api.securityscorecards.dev:443


### PR DESCRIPTION
The scorecard workflow has been failing as its network requirements have changed.   Switching to audit mode so we can capture the new requirements.

