### PR TITLE
Revert dependabot changes to actions/{upload, download}-artifact

### DIFF
--- a/.github/workflows/_scorecards.yml
+++ b/.github/workflows/_scorecards.yml
@@ -71,7 +71,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392  # tag=v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32  # tag=v3.1.3
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -324,7 +324,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ (inputs.push == false) && (inputs.artifact_name != '') }}
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392  # tag=v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32  # tag=v3.1.3
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ env.OUTPUT_ARTIFACT_WORK_DIR }}/${{ steps.check_image_archive_key.outputs.file_name }}

--- a/.github/workflows/docker-multi-arch-push.yml
+++ b/.github/workflows/docker-multi-arch-push.yml
@@ -76,7 +76,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Docker images artifact
-        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4  # tag=v4.0.0
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # tag=v3.0.2
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ env.ARTIFACT_WORK_DIR }}

--- a/.github/workflows/docker-pytest-image.yml
+++ b/.github/workflows/docker-pytest-image.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload unencrypted data artifacts
         if: ( success() || failure() ) && steps.check_data_archive_key.outputs.do_encryption == 'false'
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392  # tag=v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32  # tag=v3.1.3
         with:
           name: ${{ inputs.data_artifact_name }}
           path: data.tar.gz
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload encrypted data artifacts
         if: ( success() || failure() ) && steps.check_data_archive_key.outputs.do_encryption == 'true'
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392  # tag=v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32  # tag=v3.1.3
         with:
           name: ${{ inputs.data_artifact_name }}
           path: data.tar.7z

--- a/.github/workflows/docker-pytest-image.yml
+++ b/.github/workflows/docker-pytest-image.yml
@@ -126,7 +126,7 @@ jobs:
           pip install --upgrade --requirement requirements-test.txt
 
       - name: Download Docker image artifact
-        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4  # tag=v4.0.0
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # tag=v3.0.2
         with:
           name: ${{ inputs.image_artifact_name }}
           path: ${{ env.ARTIFACT_WORK_DIR }}

--- a/.github/workflows/sbom-artifact.yml
+++ b/.github/workflows/sbom-artifact.yml
@@ -92,7 +92,7 @@ jobs:
           done
 
       - name: Upload SBOMs as artifact
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392  # tag=v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32  # tag=v3.1.3
         with:
           name: ${{ inputs.sbom_artifact_name }}
           path: ${{ env.OUTPUT_ARTIFACT_WORK_DIR }}

--- a/.github/workflows/sbom-artifact.yml
+++ b/.github/workflows/sbom-artifact.yml
@@ -77,7 +77,7 @@ jobs:
           fi
 
       - name: Download images artifact
-        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4  # tag=v4.0.0
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # tag=v3.0.2
         with:
           name: ${{ inputs.image_artifact_name }}
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

The move from v3 to v4 of the artifact actions broke the workflows.
This PR reverts those changes.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

The dependabot PRs did not mention the breaking changes.  We need these workflows to work until we can refactor them.

See:
- https://github.com/actions/upload-artifact/issues/472

We will migrate to v4 when we can properly refactor the workflows to handle immutable artifacts:
- https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

CI only.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] All new and existing tests pass.

