### PR TITLE
Allow new network endpoints for linter workflow

### DIFF
--- a/.github/workflows/common-lint.yml
+++ b/.github/workflows/common-lint.yml
@@ -58,8 +58,11 @@ jobs:
             api.github.com:443
             files.pythonhosted.org:443
             github.com:443
+            golang.org:443
+            objects.githubusercontent.com:443
             proxy.golang.org:443
             pypi.org:443
+            raw.githubusercontent.com:443
             registry.npmjs.org:443
             sum.golang.org:443
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__
 .python-version
 *.egg-info
 venv
+
+## Rust ##
+target


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

- Allow new network endpoints required by the linter workflow.  
- Ignore rust build target directory

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

The linting job is failing across all repos with a blocked request made from the `actions/setup-go`.  
See:
- https://github.com/felddy/foundryvtt-docker/actions/runs/8122006583/job/22201013326#step:5:1

## 🧪 Testing ##

Testing in this repo's workflow.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
